### PR TITLE
Update configure.sh

### DIFF
--- a/src/configure.sh
+++ b/src/configure.sh
@@ -6,7 +6,7 @@ PINANAS_VENV="${PINANAS_DIST}/.venv"
 . ${PINANAS_SRC}/build/configure-logging.sh
 
 configure () {
-    local tag=pinanas-config
+    local tag=pinanas-config:latest
     docker build \
         --rm \
         -t ${tag} \


### PR DESCRIPTION
On my test, if missing "version" in tag, docker will search image "pinanas-config:latest" by default and not find it because not exist.