### PR TITLE
fix dependancies bcryp > rust > cargo

### DIFF
--- a/src/build/Dockerfile
+++ b/src/build/Dockerfile
@@ -12,7 +12,11 @@ RUN apk add --no-cache \
     gcc \
     musl-dev \
     libffi-dev \
-    docker-cli
+    docker-cli \
+    openssl-dev \
+    build-base \
+    rust \
+    cargo
 
 RUN mkdir -m 777 /pinanas-config
 


### PR DESCRIPTION
This fix errors with bcrypt caused by missing Rust compilator on Debian 11.
Dockerfile has been modified to add Rust and dependencies.