### PR TITLE
Feature/49 uninstall script

### DIFF
--- a/src/build/configure-guest.sh
+++ b/src/build/configure-guest.sh
@@ -154,6 +154,19 @@ EOF
     chmod +x "/pinanas/dist/distclean.sh"
 }
 
+#
+## Uninstaller-script
+#
+
+uninstaller () {
+    cat > "/pinanas/dist/uninstall.sh" <<EOF
+#!/bin/bash
+rm -r $(ls -I "settings.yml")
+docker rm -v $(docker ps --filter status=exited -q)
+docker rmi -f $(docker images -aq)
+EOF
+    chmod +x "/pinanas/dist/uninstall.sh"
+}
 
 #
 ## === ENTRY POINT ===
@@ -163,3 +176,4 @@ check "$@"
 prepare
 install "$@"
 clean
+uninstaller

--- a/src/build/configure-guest.sh
+++ b/src/build/configure-guest.sh
@@ -123,7 +123,8 @@ uninstaller () {
 #!/bin/bash
 rm -r $(ls -I "settings.yml*")
 rm -r .venv/
-docker rm -v $(docker ps --filter status=exited -q)
+docker stop $(docker ps -a -q)
+docker rm -v $(docker ps -a -q)
 docker rm $(docker volume ls -q)
 docker rmi -f $(docker images -aq)
 EOF

--- a/src/build/configure-guest.sh
+++ b/src/build/configure-guest.sh
@@ -159,9 +159,10 @@ EOF
 #
 
 uninstaller () {
-    cat > "/pinanas/dist/uninstall.sh" <<EOF
+    cat << \EOF > "/pinanas/dist/uninstall.sh"
 #!/bin/bash
 rm -r $(ls -I "settings.yml")
+rm -r .venv/
 docker rm -v $(docker ps --filter status=exited -q)
 docker rmi -f $(docker images -aq)
 EOF
@@ -174,6 +175,6 @@ EOF
 
 check "$@"
 prepare
+uninstaller
 install "$@"
 clean
-uninstaller

--- a/src/build/configure-guest.sh
+++ b/src/build/configure-guest.sh
@@ -159,11 +159,12 @@ EOF
 #
 
 uninstaller () {
-    cat << \EOF > "/pinanas/dist/uninstall.sh"
+    cat > "/pinanas/dist/uninstall.sh" << \EOF
 #!/bin/bash
 rm -r $(ls -I "settings.yml")
 rm -r .venv/
 docker rm -v $(docker ps --filter status=exited -q)
+docker rm $(docker volume ls -q)
 docker rmi -f $(docker images -aq)
 EOF
     chmod +x "/pinanas/dist/uninstall.sh"

--- a/src/build/configure-guest.sh
+++ b/src/build/configure-guest.sh
@@ -115,6 +115,23 @@ EOT
 
 
 #
+## Uninstaller-script
+#
+
+uninstaller () {
+    cat > "/pinanas/dist/uninstall.sh" << \EOF
+#!/bin/bash
+rm -r $(ls -I "settings.yml*")
+rm -r .venv/
+docker rm -v $(docker ps --filter status=exited -q)
+docker rm $(docker volume ls -q)
+docker rmi -f $(docker images -aq)
+EOF
+    chmod +x "/pinanas/dist/uninstall.sh"
+}
+
+
+#
 ## Install
 #
 
@@ -154,21 +171,6 @@ EOF
     chmod +x "/pinanas/dist/distclean.sh"
 }
 
-#
-## Uninstaller-script
-#
-
-uninstaller () {
-    cat > "/pinanas/dist/uninstall.sh" << \EOF
-#!/bin/bash
-rm -r $(ls -I "settings.yml")
-rm -r .venv/
-docker rm -v $(docker ps --filter status=exited -q)
-docker rm $(docker volume ls -q)
-docker rmi -f $(docker images -aq)
-EOF
-    chmod +x "/pinanas/dist/uninstall.sh"
-}
 
 #
 ## === ENTRY POINT ===

--- a/src/configure.sh
+++ b/src/configure.sh
@@ -35,6 +35,8 @@ report () {
     info "Configuration successful."
     cont "You can clean work files with ./distclean.sh"
     cont "Start your services with docker-compose up -d"
+    cont ""
+    cont "You can uninstall all with ./uninstall.sh if needed"
 
     command -v netstat >/dev/null || return
     if netstat -lan | grep -qE ':53\W' ; then


### PR DESCRIPTION
This script proposal allows, in the PiNanas installation folder, to remove:
- all directories and files except "settings.yml*" (if like "settings.yml.backup" was created and wanted keep)
- uninstall.sh itself
- all docker containers, volumes and images created

This script is created before running ansible playbooks => in case of error during installation (e.g. due to settings bad configuration), it could be used.